### PR TITLE
Use flow-win64 on Windows on Arm

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,6 @@ module.exports =
     ? path.join(__dirname, 'flow-linux64-v' + VERSION, 'flow') :
   process.platform === 'linux' && process.arch === 'arm64'
     ? path.join(__dirname, 'flow-linux-arm64-v' + VERSION, 'flow') :
-  process.platform === 'win32' &&  process.arch === 'x64'
+  process.platform === 'win32' &&  (process.arch === 'x64' || process.arch === 'arm64')
     ? path.join(__dirname, 'flow-win64-v' + VERSION, 'flow.exe') :
   null;


### PR DESCRIPTION
There is no native binary for win32-arm64 yet. Windows on Arm can run the x64 variant through emulation.