### PR TITLE
Update readme file with source code information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,9 @@
 
 macOS (x64), Linux (x64, arm64) and Windows (x64) binaries are currently [provided](https://flow.org/en/docs/install/).
 
+## Source Code
+
+The source code for Flow can be found in the [facebook/flow](https://github.com/facebook/flow) repository. This repository (`flow-bin`) provides binary releases for Flow.
 
 ## CLI
 


### PR DESCRIPTION
### Title: docs: Update README to Point to facebook/flow Repository
### Description:
This pull request addresses issue [#120](https://github.com/flow/flow-bin/issues/120) by updating the README file to include a reference to the [facebook/flow](https://github.com/facebook/flow) repository. This change clarifies that the flow-bin repository provides binary releases for Flow, while the source code is maintained in the facebook/flow repository.

### Changes Made:
Added a new section in the README file to guide users to the source code repository.

### Motivation and Context:
The flow-bin repository only contains binary releases, whereas the actual source code is hosted in the facebook/flow repository. This update ensures that users are directed to the correct repository for source code, contributing, and additional documentation.

### Related Issue:
Fixes [#120](https://github.com/flow/flow-bin/issues/120)

### Types of Changes:
Documentation update